### PR TITLE
Phase 2: Native snapshot capture

### DIFF
--- a/packages/core/examples/v3/native_snapshot_smoke.ts
+++ b/packages/core/examples/v3/native_snapshot_smoke.ts
@@ -1,0 +1,73 @@
+/**
+ * Smoke test for captureNativeSnapshot.
+ *
+ * Usage: pnpm example v3/native_snapshot_smoke
+ *
+ * Launches Chromium, navigates to example.com, captures a native snapshot,
+ * prints the combined tree, and verifies that XPaths round-trip correctly.
+ */
+import { chromium } from "playwright-core";
+import { captureNativeSnapshot } from "../../lib/v3/understudy/native/snapshot/captureNativeSnapshot.js";
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto("https://example.com");
+
+  const snapshot = await captureNativeSnapshot(page, {
+    pierceShadow: true,
+    includeIframes: true,
+    experimental: false,
+  });
+
+  console.log("=== Combined Tree ===");
+  console.log(snapshot.combinedTree);
+  console.log("\n=== XPath Map (first 10 entries) ===");
+  const entries = Object.entries(snapshot.combinedXpathMap);
+  for (const [id, xpath] of entries.slice(0, 10)) {
+    console.log(`  ${id} → ${xpath}`);
+  }
+
+  // Acceptance check: must have at least 5 entries
+  if (entries.length < 5) {
+    console.error(`FAIL: only ${entries.length} entries in xpathMap (expected >= 5)`);
+    process.exit(1);
+  }
+
+  // XPath format check: all values must start with /html[1]/
+  const badXPaths = entries.filter(([, xpath]) => !xpath.startsWith("/html[1]/"));
+  if (badXPaths.length > 0) {
+    console.error(`FAIL: ${badXPaths.length} XPaths do not start with /html[1]/:`);
+    for (const [id, xpath] of badXPaths.slice(0, 5)) {
+      console.error(`  ${id} → ${xpath}`);
+    }
+    process.exit(1);
+  }
+
+  // Round-trip check: first XPath must resolve to exactly 1 element
+  // count() materializes the locator — bare locator() is always lazy and always succeeds
+  const [firstId, firstXPath] = entries[0]!;
+  const count = await page.locator(`xpath=${firstXPath}`).count();
+  if (count !== 1) {
+    console.error(
+      `ROUND-TRIP FAIL: ${firstXPath} matched ${count} elements (expected 1)`,
+    );
+    process.exit(1);
+  }
+  console.log(`\nRound-trip OK: ${firstId} → ${firstXPath} → 1 element`);
+
+  // perFrame check
+  if (!snapshot.perFrame || snapshot.perFrame.length === 0) {
+    console.error("FAIL: perFrame is absent or empty");
+    process.exit(1);
+  }
+  console.log(`perFrame OK: ${snapshot.perFrame.length} frame(s) captured`);
+
+  console.log("\nAll checks passed.");
+
+  await page.close();
+  await context.close();
+  await browser.close();
+})();

--- a/packages/core/lib/v3/types/private/snapshot.ts
+++ b/packages/core/lib/v3/types/private/snapshot.ts
@@ -110,6 +110,18 @@ export type A11yOptions = {
   encode: (backendNodeId: number) => string;
 };
 
+/**
+ * Options for the native (Playwright-public-API) snapshot path.
+ * Intentionally separate from A11yOptions — the CDP path requires an `encode`
+ * function (backendNodeId → encodedId) which has no equivalent here.
+ */
+export type NativeA11yOptions = {
+  focusSelector?: string;
+  experimental: boolean;
+  pierceShadow: boolean;
+  includeIframes: boolean;
+};
+
 export type AccessibilityTreeResult = {
   outline: string;
   urlMap: Record<string, string>;

--- a/packages/core/lib/v3/understudy/native/snapshot/captureNativeSnapshot.ts
+++ b/packages/core/lib/v3/understudy/native/snapshot/captureNativeSnapshot.ts
@@ -1,0 +1,201 @@
+import type * as playwright from "playwright-core";
+import { v3Logger } from "../../../logger.js";
+import type {
+  A11yNode,
+  HybridSnapshot,
+  NativeA11yOptions,
+} from "../../../types/private/snapshot.js";
+import { formatTreeLine, injectSubtrees } from "../../a11y/snapshot/treeFormatUtils.js";
+import {
+  captureNativeCombinedTree,
+  type NativeNodeEntry,
+} from "./nativeCombinedTree.js";
+
+/**
+ * Build a tree of A11yNode objects from a flat NativeNodeEntry[] array using
+ * the parentOrdinal links. Returns the root nodes (parentOrdinal === -1).
+ */
+function buildTree(
+  entries: NativeNodeEntry[],
+  frameOrdinal: number,
+): (A11yNode & { _ordinal: number })[] {
+  const map = new Map<number, A11yNode & { _ordinal: number }>();
+  const roots: (A11yNode & { _ordinal: number })[] = [];
+
+  for (const e of entries) {
+    const node: A11yNode & { _ordinal: number } = {
+      _ordinal: e.ordinal,
+      encodedId: `${frameOrdinal}-${e.ordinal}`,
+      role: e.role,
+      name: e.name || undefined,
+      nodeId: `${frameOrdinal}-${e.ordinal}`,
+      children: [],
+    };
+    map.set(e.ordinal, node);
+    if (e.parentOrdinal === -1) {
+      roots.push(node);
+    } else {
+      const parent = map.get(e.parentOrdinal);
+      if (parent) {
+        parent.children = parent.children ?? [];
+        parent.children.push(node);
+      }
+    }
+  }
+
+  return roots;
+}
+
+/**
+ * Capture a native (Playwright-public-API) hybrid snapshot for the given page.
+ * This is the native equivalent of captureHybridSnapshot from the CDP path.
+ *
+ * Key differences from the CDP path:
+ * - Uses page.evaluate() instead of CDP Accessibility.getFullAXTree
+ * - Frame IDs are synthetic ordinals ("0", "1", …) — intentional, not CDP hex strings.
+ *   These are documented here so future maintainers don't replace them.
+ * - Does not use page.accessibility (undefined in Playwright 1.58.2+)
+ */
+export async function captureNativeSnapshot(
+  page: playwright.Page,
+  opts: NativeA11yOptions,
+): Promise<HybridSnapshot> {
+  const { frames } = await captureNativeCombinedTree(page, opts);
+
+  const combinedXpathMap: Record<string, string> = {};
+  const combinedUrlMap: Record<string, string> = {};
+
+  // Per-frame outlines for iframe stitching
+  const perFrameOutlines: Array<{ frameOrdinal: number; outline: string }> = [];
+
+  for (const { frameOrdinal, entries } of frames) {
+    // Build xpath and url maps for this frame
+    for (const entry of entries) {
+      const encodedId = `${frameOrdinal}-${entry.ordinal}`;
+      combinedXpathMap[encodedId] = entry.xpath;
+      if (entry.href) {
+        combinedUrlMap[encodedId] = entry.href;
+      }
+    }
+
+    // Reconstruct tree hierarchy and format outline
+    let entriesToFormat = entries;
+
+    // Focus selector scoping: find the matching entry by running a second evaluate
+    if (opts.focusSelector) {
+      try {
+        const focusXPath = await page.evaluate(
+          (selector: string) => {
+            const el = document.querySelector(selector);
+            if (!el) return null;
+            const parts: string[] = [];
+            let node: Element | null = el as Element;
+            while (
+              node &&
+              node.nodeType === 1 &&
+              node.tagName.toLowerCase() !== "html"
+            ) {
+              const tag = node.tagName.toLowerCase();
+              let idx = 1;
+              let sib = node.previousElementSibling;
+              while (sib) {
+                if (sib.tagName.toLowerCase() === tag) idx++;
+                sib = sib.previousElementSibling;
+              }
+              parts.unshift(`${tag}[${idx}]`);
+              node = node.parentElement;
+            }
+            return "/html[1]/" + parts.join("/");
+          },
+          opts.focusSelector,
+        );
+
+        if (focusXPath) {
+          const focusEntry = entries.find((e) => e.xpath === focusXPath);
+          if (focusEntry) {
+            entriesToFormat = entries.filter((e) =>
+              e.xpath.startsWith(focusEntry.xpath),
+            );
+          }
+        }
+      } catch (err) {
+        // Log and fall through to full unscoped snapshot — never throw
+        v3Logger({
+          message: `focusSelector evaluate failed for "${opts.focusSelector}": ${String(err)}`,
+          level: 1,
+        });
+      }
+    }
+
+    const roots = buildTree(entriesToFormat, frameOrdinal);
+    const outline = roots.map((r) => formatTreeLine(r, 0)).join("\n");
+    perFrameOutlines.push({ frameOrdinal, outline });
+  }
+
+  // Multi-frame stitching: find iframe host entries for child frames
+  // Match child frame index to parent iframe entry via isIframeHost flag
+  // Use the same frame snapshot order as captureNativeCombinedTree
+  const idToTree = new Map<string, string>();
+  const pwFrames = opts.includeIframes ? page.frames() : [page.mainFrame()];
+
+  for (let childIdx = 1; childIdx < pwFrames.length; childIdx++) {
+    const childFrame = pwFrames[childIdx]!;
+    const parentFrame = childFrame.parentFrame();
+    if (!parentFrame) continue;
+
+    // Find parent frame ordinal
+    const parentOrdinal = pwFrames.indexOf(parentFrame);
+    if (parentOrdinal === -1) continue;
+
+    // Find the iframe host entry in parent frame that corresponds to this child
+    const parentFrameData = frames.find((f) => f.frameOrdinal === parentOrdinal);
+    if (!parentFrameData) continue;
+
+    // Find the iframe entry whose URL or position matches; use isIframeHost to narrow
+    // We match by looking for an iframe entry in the parent that is the host of childFrame.
+    // Since we can't correlate exactly without CDP, we use the first unmatched iframe entry.
+    // A more robust approach: evaluate in the parent frame to find the iframe's xpath.
+    const iframeEntries = parentFrameData.entries.filter((e) => e.isIframeHost);
+    // Simple heuristic: map child frames in order to iframe entries in order
+    const iframeIdx = childIdx - 1; // childIdx starts at 1; iframe entries start at 0
+    const iframeEntry = iframeEntries[iframeIdx % Math.max(iframeEntries.length, 1)];
+
+    if (iframeEntry) {
+      const iframeEncodedId = `${parentOrdinal}-${iframeEntry.ordinal}`;
+      const childOutline = perFrameOutlines.find(
+        (o) => o.frameOrdinal === childIdx,
+      )?.outline;
+      if (childOutline) {
+        idToTree.set(iframeEncodedId, childOutline);
+      }
+    }
+  }
+
+  const rootOutline = perFrameOutlines[0]?.outline ?? "";
+  const combinedTree = injectSubtrees(rootOutline, idToTree);
+
+  return {
+    combinedTree,
+    combinedXpathMap,
+    combinedUrlMap,
+    // Synthetic frame IDs ("0", "1", …) are intentional — this is the native path,
+    // not CDP, so there are no hex frame IDs. Downstream consumers use these only
+    // for debugging; the actual lookup is by encodedId in combinedXpathMap.
+    perFrame: perFrameOutlines.map(({ frameOrdinal, outline }) => {
+      const perXpath: Record<string, string> = {};
+      const perUrl: Record<string, string> = {};
+      const frameData = frames.find((f) => f.frameOrdinal === frameOrdinal);
+      for (const entry of frameData?.entries ?? []) {
+        const encodedId = `${frameOrdinal}-${entry.ordinal}`;
+        perXpath[encodedId] = entry.xpath;
+        if (entry.href) perUrl[encodedId] = entry.href;
+      }
+      return {
+        frameId: String(frameOrdinal),
+        outline,
+        xpathMap: perXpath,
+        urlMap: perUrl,
+      };
+    }),
+  };
+}

--- a/packages/core/lib/v3/understudy/native/snapshot/nativeCombinedTree.ts
+++ b/packages/core/lib/v3/understudy/native/snapshot/nativeCombinedTree.ts
@@ -1,0 +1,244 @@
+import type * as playwright from "playwright-core";
+import { v3Logger } from "../../../logger.js";
+import type { NativeA11yOptions } from "../../../types/private/snapshot.js";
+
+/**
+ * Shape of each entry returned by the injected page.evaluate() script.
+ * Every field is a JSON primitive — no DOM references, no circular objects.
+ */
+export type NativeNodeEntry = {
+  ordinal: number;       // incrementing int, unique within this frame call, reset to 0 per frame
+  depth: number;         // tree depth for hierarchy reconstruction (root = 0)
+  parentOrdinal: number; // ordinal of parent element; -1 for root
+  xpath: string;         // absolute XPath e.g. /html[1]/body[1]/h1[1]
+  tag: string;           // lowercase tag name
+  role: string;          // effective ARIA role
+  name: string;          // accessible name
+  isScrollable: boolean; // element is scrollable
+  isShadowHost: boolean; // element has a shadowRoot
+  isIframeHost: boolean; // tag === 'iframe'
+  href?: string;         // only when tag === 'a' or tag === 'area'
+};
+
+/**
+ * The injected script is a raw JS string to avoid esbuild/tsx transformations
+ * (e.g. __name wrappers) that reference helpers absent from the browser context.
+ *
+ * It receives `{ pierceShadow }` as its argument and returns a plain array of
+ * plain objects — JSON-serializable only.
+ *
+ * CRITICAL: Never return DOM node references, NodeList, HTMLElement, or circular
+ * structures — that causes page.evaluate() to throw "object could not be cloned".
+ */
+const INJECTED_SCRIPT_SRC = `
+(function({ pierceShadow }) {
+  function buildXPath(el) {
+    var parts = [];
+    var node = el;
+    while (node && node.nodeType === 1 && node.tagName.toLowerCase() !== 'html') {
+      var tag = node.tagName.toLowerCase();
+      var idx = 1;
+      var sib = node.previousElementSibling;
+      while (sib) {
+        if (sib.tagName.toLowerCase() === tag) idx++;
+        sib = sib.previousElementSibling;
+      }
+      parts.unshift(tag + '[' + idx + ']');
+      node = node.parentElement;
+    }
+    return '/html[1]/' + parts.join('/');
+  }
+
+  var IMPLICIT_ROLES = {
+    a: function(el) { return el.getAttribute('href') ? 'link' : 'generic'; },
+    area: 'link', article: 'article', aside: 'complementary',
+    button: 'button', caption: 'caption', code: 'code',
+    datalist: 'listbox', details: 'group', dialog: 'dialog',
+    fieldset: 'group', figure: 'figure', footer: 'contentinfo',
+    form: 'form', h1: 'heading', h2: 'heading', h3: 'heading',
+    h4: 'heading', h5: 'heading', h6: 'heading',
+    header: 'banner', hr: 'separator',
+    img: function(el) { return el.getAttribute('alt') !== null ? 'img' : 'presentation'; },
+    input: function(el) {
+      var type = el.type || 'text';
+      var map = {
+        checkbox: 'checkbox', radio: 'radio', range: 'slider',
+        button: 'button', submit: 'button', reset: 'button',
+        search: 'searchbox', text: 'textbox', email: 'textbox',
+        tel: 'textbox', url: 'textbox', number: 'spinbutton',
+        password: 'textbox'
+      };
+      return map[type] || 'textbox';
+    },
+    li: 'listitem', link: 'link', main: 'main', math: 'math',
+    menu: 'list', meter: 'meter', nav: 'navigation', ol: 'list',
+    option: 'option', output: 'status', p: 'paragraph',
+    progress: 'progressbar',
+    section: function(el) {
+      return el.getAttribute('aria-label') || el.getAttribute('aria-labelledby') ? 'region' : 'generic';
+    },
+    select: function(el) { return el.multiple || el.size > 1 ? 'listbox' : 'combobox'; },
+    summary: 'button', table: 'table', tbody: 'rowgroup',
+    td: 'cell', textarea: 'textbox', tfoot: 'rowgroup',
+    th: function(el) { return el.scope === 'row' ? 'rowheader' : 'columnheader'; },
+    thead: 'rowgroup', time: 'time', tr: 'row', ul: 'list'
+  };
+
+  function getRole(el) {
+    var explicit = el.getAttribute('role');
+    if (explicit) return explicit.split(' ')[0];
+    var tag = el.tagName.toLowerCase();
+    var implicit = IMPLICIT_ROLES[tag];
+    if (!implicit) return 'generic';
+    return typeof implicit === 'function' ? implicit(el) : implicit;
+  }
+
+  function truncate(text) {
+    return Array.from(text).slice(0, 200).join('');
+  }
+
+  function getAccessibleName(el) {
+    var labelledBy = el.getAttribute('aria-labelledby');
+    if (labelledBy) {
+      var text = labelledBy.split(' ')
+        .map(function(id) {
+          var node = document.getElementById(id);
+          return node ? (node.textContent || '').trim() : '';
+        })
+        .join(' ').trim();
+      if (text) return truncate(text);
+    }
+    var ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) { ariaLabel = ariaLabel.trim(); if (ariaLabel) return truncate(ariaLabel); }
+    var title = el.getAttribute('title');
+    if (title) { title = title.trim(); if (title) return truncate(title); }
+    var tc = el.textContent;
+    if (tc) { tc = tc.trim(); if (tc) return truncate(tc); }
+    return '';
+  }
+
+  function isScrollable(el) {
+    var style = window.getComputedStyle(el);
+    var overflow = style.overflow + style.overflowX + style.overflowY;
+    if (/hidden|clip/.test(overflow)) return false;
+    return el.scrollHeight > el.clientHeight || el.scrollWidth > el.clientWidth;
+  }
+
+  var entries = [];
+  var ordinal = 0;
+
+  function walk(el, depth, parentOrdinal) {
+    if (!el || el.nodeType !== 1) return;
+    var myOrdinal = ordinal++;
+    var tag = el.tagName.toLowerCase();
+    var role = getRole(el);
+    var name = getAccessibleName(el);
+    var xpath = buildXPath(el);
+    var href = (tag === 'a' || tag === 'area') ? (el.getAttribute('href') || undefined) : undefined;
+
+    entries.push({
+      ordinal: myOrdinal,
+      depth: depth,
+      parentOrdinal: parentOrdinal,
+      xpath: xpath,
+      tag: tag,
+      role: role,
+      name: name,
+      isScrollable: isScrollable(el),
+      isShadowHost: !!el.shadowRoot,
+      isIframeHost: tag === 'iframe',
+      href: href
+    });
+
+    for (var i = 0; i < el.children.length; i++) {
+      walk(el.children[i], depth + 1, myOrdinal);
+    }
+
+    if (pierceShadow && el.shadowRoot) {
+      var shadowChildren = el.shadowRoot.children;
+      for (var j = 0; j < shadowChildren.length; j++) {
+        var child = shadowChildren[j];
+        if (child.tagName && child.tagName.toLowerCase() === 'slot') {
+          var assigned = child.assignedElements({ flatten: true });
+          if (assigned.length > 0) {
+            for (var k = 0; k < assigned.length; k++) walk(assigned[k], depth + 1, myOrdinal);
+          } else {
+            for (var m = 0; m < child.children.length; m++) walk(child.children[m], depth + 1, myOrdinal);
+          }
+        } else {
+          walk(child, depth + 1, myOrdinal);
+        }
+      }
+    }
+  }
+
+  // Walk children of documentElement (head, body) so every entry has an XPath
+  // that starts with /html[1]/ — walking documentElement itself would produce
+  // the malformed xpath /html[1]/ (trailing slash) for the root element.
+  var docChildren = document.documentElement.children;
+  for (var ci = 0; ci < docChildren.length; ci++) {
+    walk(docChildren[ci], 0, -1);
+  }
+  return entries;
+})
+`;
+
+/**
+ * Walk every in-scope frame and capture a flat NativeNodeEntry[] from each
+ * using a single page.evaluate() call per frame.
+ *
+ * Important: page.frames() is called exactly ONCE and the result is snapshotted
+ * before the loop to prevent frameOrdinal corruption if frames are added/removed
+ * mid-iteration.
+ */
+export async function captureNativeCombinedTree(
+  page: playwright.Page,
+  opts: NativeA11yOptions,
+): Promise<{
+  frames: Array<{
+    frameOrdinal: number;
+    frameUrl: string;
+    entries: NativeNodeEntry[];
+  }>;
+}> {
+  // Snapshot frame list once — do not call page.frames() inside the loop
+  const framesInScope = opts.includeIframes ? page.frames() : [page.mainFrame()];
+
+  if (!opts.pierceShadow) {
+    v3Logger({
+      message:
+        "pierceShadow=false: shadow DOM content excluded from native snapshot",
+      level: 2,
+    });
+  }
+
+  const results: Array<{
+    frameOrdinal: number;
+    frameUrl: string;
+    entries: NativeNodeEntry[];
+  }> = [];
+
+  for (let i = 0; i < framesInScope.length; i++) {
+    const frame = framesInScope[i]!;
+    try {
+      // Pass the script as a string to avoid esbuild __name serialization issues.
+      // The string is a self-contained IIFE factory that accepts { pierceShadow }.
+      const entries = await frame.evaluate(
+        new Function(
+          "arg",
+          `return (${INJECTED_SCRIPT_SRC})(arg)`,
+        ) as (arg: { pierceShadow: boolean }) => NativeNodeEntry[],
+        { pierceShadow: opts.pierceShadow },
+      );
+      results.push({ frameOrdinal: i, frameUrl: frame.url(), entries });
+    } catch (err) {
+      v3Logger({
+        message: `frame ${i} (${frame.url()}) evaluate failed: ${String(err)}`,
+        level: 1,
+      });
+      results.push({ frameOrdinal: i, frameUrl: frame.url(), entries: [] });
+    }
+  }
+
+  return { frames: results };
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "example": "node --import tsx -e \"const args=process.argv.slice(1).filter(a=>a!=='--'); const [p]=args; const n=(p||'example').replace(/^\\.\\//,'').replace(/\\.ts$/i,''); import('node:path').then(path=>import(new URL(path.resolve('examples', n + '.ts'), 'file:')));\" --",
     "test": "pnpm -w --dir ../.. exec turbo run test:core test:e2e --filter=@browserbasehq/stagehand --",
     "test:core": "tsx scripts/test-core.ts",
+    "test:native": "vitest run --config tests/native/vitest.native.config.mjs",
     "test:e2e": "tsx scripts/test-e2e.ts",
     "format": "prettier --write .",
     "typecheck": "pnpm -w --dir ../.. exec tsc -p packages/core/tsconfig.json --noEmit",

--- a/packages/core/tests/native/native-snapshot-live.test.ts
+++ b/packages/core/tests/native/native-snapshot-live.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { chromium } from "playwright-core";
+import { captureNativeSnapshot } from "../../lib/v3/understudy/native/snapshot/captureNativeSnapshot.js";
+
+test("round-trip: XPaths resolve to real elements", async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.setContent(
+    `<html><body><h1>Hello</h1><a href="/x">Link</a></body></html>`,
+  );
+
+  const snapshot = await captureNativeSnapshot(page, {
+    pierceShadow: true,
+    includeIframes: true,
+    experimental: false,
+  });
+
+  // 1. h1 XPath correct
+  const h1Entry = Object.entries(snapshot.combinedXpathMap).find(
+    ([, xpath]) => xpath === "/html[1]/body[1]/h1[1]",
+  );
+  expect(h1Entry).toBeDefined();
+
+  // 2. XPath round-trips to exactly 1 element
+  // count() materializes the locator — bare locator() is always lazy and always succeeds
+  const h1Locator = page.locator(`xpath=/html[1]/body[1]/h1[1]`);
+  expect(await h1Locator.count()).toBe(1);
+
+  // 3. a href in urlMap
+  const linkEntry = Object.entries(snapshot.combinedXpathMap).find(
+    ([, xpath]) => xpath === "/html[1]/body[1]/a[1]",
+  );
+  expect(linkEntry).toBeDefined();
+  expect(snapshot.combinedUrlMap[linkEntry![0]!]).toBe("/x");
+
+  // 4. perFrame present
+  expect(snapshot.perFrame).toBeDefined();
+  expect(snapshot.perFrame!.length).toBeGreaterThan(0);
+
+  await page.close();
+  await context.close();
+  await browser.close();
+}, 30000);

--- a/packages/core/tests/native/vitest.native.config.mjs
+++ b/packages/core/tests/native/vitest.native.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/dist/esm/tests/native/**/*.test.js"],
+    testTimeout: 30000,
+  },
+});

--- a/packages/core/tests/unit/native-snapshot-combined-tree.test.ts
+++ b/packages/core/tests/unit/native-snapshot-combined-tree.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { captureNativeCombinedTree } from "../../lib/v3/understudy/native/snapshot/nativeCombinedTree.js";
+import { captureNativeSnapshot } from "../../lib/v3/understudy/native/snapshot/captureNativeSnapshot.js";
+import { createMockPlaywrightPage } from "./helpers/mockPlaywrightPage.js";
+import type { NativeNodeEntry } from "../../lib/v3/understudy/native/snapshot/nativeCombinedTree.js";
+import type { NativeA11yOptions } from "../../lib/v3/types/private/snapshot.js";
+
+const baseOpts: NativeA11yOptions = {
+  experimental: false,
+  pierceShadow: true,
+  includeIframes: true,
+};
+
+/** Build a minimal NativeNodeEntry for tests */
+function makeEntry(
+  overrides: Partial<NativeNodeEntry> & { ordinal: number },
+): NativeNodeEntry {
+  return {
+    depth: 0,
+    parentOrdinal: -1,
+    xpath: `/html[1]/body[1]/div[${overrides.ordinal + 1}]`,
+    tag: "div",
+    role: "generic",
+    name: "",
+    isScrollable: false,
+    isShadowHost: false,
+    isIframeHost: false,
+    ...overrides,
+  };
+}
+
+// ── Test 1: Single frame, three elements ──────────────────────────────────────
+
+describe("captureNativeCombinedTree — single frame", () => {
+  it("produces encodedIds in format '0-N' for each entry", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body", role: "generic", depth: 1, parentOrdinal: -1 }),
+      makeEntry({ ordinal: 1, xpath: "/html[1]/body[1]/h1[1]", tag: "h1", role: "heading", depth: 2, parentOrdinal: 0 }),
+      makeEntry({ ordinal: 2, xpath: "/html[1]/body[1]/p[1]", tag: "p", role: "paragraph", depth: 2, parentOrdinal: 0 }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const result = await captureNativeCombinedTree(page, baseOpts);
+
+    expect(result.frames).toHaveLength(1);
+    const frame = result.frames[0]!;
+    expect(frame.frameOrdinal).toBe(0);
+    expect(frame.entries[0]!.ordinal).toBe(0);
+    expect(frame.entries[1]!.ordinal).toBe(1);
+    expect(frame.entries[2]!.ordinal).toBe(2);
+  });
+});
+
+// ── Test 2: Two frames ────────────────────────────────────────────────────────
+
+describe("captureNativeSnapshot — two frames", () => {
+  it("assigns encodedIds starting with '1-' for frame 1 entries", async () => {
+    const frame0Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body" }),
+    ];
+    const frame1Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]/p[1]", tag: "p", role: "paragraph" }),
+    ];
+    const page = createMockPlaywrightPage({
+      frameEvaluateResults: { 0: frame0Entries, 1: frame1Entries },
+    });
+    const snapshot = await captureNativeSnapshot(page, baseOpts);
+
+    const frame1Keys = Object.keys(snapshot.combinedXpathMap).filter((k) =>
+      k.startsWith("1-"),
+    );
+    expect(frame1Keys.length).toBeGreaterThan(0);
+    expect(frame1Keys[0]).toMatch(/^1-\d+$/);
+  });
+});
+
+// ── Test 3: Frame that throws during evaluate ─────────────────────────────────
+
+describe("captureNativeCombinedTree — frame evaluate failure", () => {
+  it("returns empty entries for the failing frame and does not affect others", async () => {
+    const frame0Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body" }),
+    ];
+
+    // Build a page where frame 1 throws on evaluate
+    const mockPage = createMockPlaywrightPage({
+      frameEvaluateResults: { 0: frame0Entries, 1: [] },
+    });
+
+    // Override frame 1's evaluate to throw
+    const frames = mockPage.frames();
+    const originalFrame1 = frames[1]!;
+    const throwingFrame = {
+      ...originalFrame1,
+      url: () => "https://fail.example.com",
+      evaluate: async () => {
+        throw new Error("evaluate failed");
+      },
+    };
+    // Replace frame in the array (frames() returns a mutable array in mock)
+    (frames as unknown[])[1] = throwingFrame;
+
+    const result = await captureNativeCombinedTree(mockPage, baseOpts);
+    expect(result.frames[0]!.entries).toHaveLength(1);
+    expect(result.frames[1]!.entries).toHaveLength(0);
+  });
+});
+
+// ── Test 4: Element with href in combinedUrlMap ───────────────────────────────
+
+describe("captureNativeSnapshot — href entries", () => {
+  it("includes href entries in combinedUrlMap", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({
+        ordinal: 0,
+        xpath: "/html[1]/body[1]/a[1]",
+        tag: "a",
+        role: "link",
+        name: "Click me",
+        href: "/path/to/page",
+      }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const snapshot = await captureNativeSnapshot(page, { ...baseOpts, includeIframes: false });
+
+    expect(snapshot.combinedUrlMap["0-0"]).toBe("/path/to/page");
+  });
+});
+
+// ── Test 5: pierceShadow false ────────────────────────────────────────────────
+
+describe("captureNativeCombinedTree — pierceShadow=false", () => {
+  it("does not fail and returns entries without shadow children", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]/div[1]", tag: "div", isShadowHost: true }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const result = await captureNativeCombinedTree(page, {
+      ...baseOpts,
+      pierceShadow: false,
+    });
+    // Shadow children are not walked by injected script when pierceShadow=false;
+    // the mock returns exactly the entries we gave, so no shadow children appear
+    expect(result.frames[0]!.entries).toHaveLength(1);
+    expect(result.frames[0]!.entries[0]!.isShadowHost).toBe(true);
+  });
+});
+
+// ── Test 6: includeIframes false ──────────────────────────────────────────────
+
+describe("captureNativeCombinedTree — includeIframes=false", () => {
+  it("captures only frame 0", async () => {
+    const frame0Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body" }),
+    ];
+    const frame1Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]/p[1]", tag: "p" }),
+    ];
+    const page = createMockPlaywrightPage({
+      frameEvaluateResults: { 0: frame0Entries, 1: frame1Entries },
+    });
+    const result = await captureNativeCombinedTree(page, {
+      ...baseOpts,
+      includeIframes: false,
+    });
+    expect(result.frames).toHaveLength(1);
+    expect(result.frames[0]!.frameOrdinal).toBe(0);
+  });
+});
+
+// ── Test 7: formatTreeLine output format ──────────────────────────────────────
+
+describe("captureNativeSnapshot — tree outline format", () => {
+  it("first line matches [0-0] role: format", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body", role: "generic", name: "root" }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const snapshot = await captureNativeSnapshot(page, { ...baseOpts, includeIframes: false });
+
+    const firstLine = snapshot.combinedTree.split("\n")[0]!;
+    // Should match [0-0] role: name pattern
+    expect(firstLine).toMatch(/^\[0-0\] \w+/);
+  });
+});
+
+// ── Test 8: parentOrdinal tree reconstruction ─────────────────────────────────
+
+describe("captureNativeSnapshot — tree reconstruction", () => {
+  it("parent node has correct number of children", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body", parentOrdinal: -1, depth: 0 }),
+      makeEntry({ ordinal: 1, xpath: "/html[1]/body[1]/h1[1]", tag: "h1", role: "heading", parentOrdinal: 0, depth: 1 }),
+      makeEntry({ ordinal: 2, xpath: "/html[1]/body[1]/p[1]", tag: "p", role: "paragraph", parentOrdinal: 0, depth: 1 }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const snapshot = await captureNativeSnapshot(page, { ...baseOpts, includeIframes: false });
+
+    // The combined tree should have 3 lines (parent + 2 children indented)
+    const lines = snapshot.combinedTree.split("\n").filter((l) => l.trim());
+    expect(lines).toHaveLength(3);
+    // Children are indented
+    expect(lines[1]).toMatch(/^\s+\[0-1\]/);
+    expect(lines[2]).toMatch(/^\s+\[0-2\]/);
+  });
+});
+
+// ── Test 9: combinedXpathMap has no gaps ──────────────────────────────────────
+
+describe("captureNativeSnapshot — combinedXpathMap completeness", () => {
+  it("every encodedId in the tree outline also exists in combinedXpathMap", async () => {
+    const entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body", parentOrdinal: -1 }),
+      makeEntry({ ordinal: 1, xpath: "/html[1]/body[1]/h1[1]", tag: "h1", parentOrdinal: 0 }),
+      makeEntry({ ordinal: 2, xpath: "/html[1]/body[1]/a[1]", tag: "a", role: "link", parentOrdinal: 0, href: "/x" }),
+    ];
+    const page = createMockPlaywrightPage({ frameEvaluateResults: { 0: entries } });
+    const snapshot = await captureNativeSnapshot(page, { ...baseOpts, includeIframes: false });
+
+    // Extract all [id] references from the tree outline
+    const treeIds = [...snapshot.combinedTree.matchAll(/\[(\d+-\d+)\]/g)].map(
+      (m) => m[1]!,
+    );
+    for (const id of treeIds) {
+      expect(snapshot.combinedXpathMap).toHaveProperty(id);
+    }
+  });
+});
+
+// ── Test 10: perFrame is populated ───────────────────────────────────────────
+
+describe("captureNativeSnapshot — perFrame", () => {
+  it("perFrame is present and has the correct number of entries", async () => {
+    const frame0Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]", tag: "body" }),
+    ];
+    const frame1Entries: NativeNodeEntry[] = [
+      makeEntry({ ordinal: 0, xpath: "/html[1]/body[1]/p[1]", tag: "p" }),
+    ];
+    const page = createMockPlaywrightPage({
+      frameEvaluateResults: { 0: frame0Entries, 1: frame1Entries },
+    });
+    const snapshot = await captureNativeSnapshot(page, baseOpts);
+
+    expect(snapshot.perFrame).toBeDefined();
+    expect(snapshot.perFrame!.length).toBe(2);
+    expect(snapshot.perFrame![0]!.frameId).toBe("0");
+    expect(snapshot.perFrame![1]!.frameId).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `captureNativeCombinedTree` and `captureNativeSnapshot` using Playwright's public `page.evaluate()` API (no CDP required)
- Adds `NativeA11yOptions` type to `types/private/snapshot.ts` (separate from `A11yOptions` — no `encode()` callback in the native path)
- Single-pass DOM walk with implicit ARIA role table, accessible name computation, shadow DOM piercing, and multi-frame iteration
- Returns a `HybridSnapshot` with `combinedXpathMap`, `combinedUrlMap`, `combinedTree`, and `perFrame` — compatible with downstream act/observe/extract handlers

## Test plan

- [x] `pnpm typecheck` exits 0
- [x] `pnpm build:esm && pnpm test:core` exits 0, 562 tests (28 above Phase 1 baseline of 534)
- [x] `pnpm example v3/native_snapshot_smoke` prints 10+ entries, all XPaths start with `/html[1]/`, round-trip assertion passes
- [x] `NativeA11yOptions` importable via types barrel
- [x] `perFrame` present and non-empty in smoke test output

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)