### PR TITLE
Phase 4: Wire PlaywrightNativeContext and browserContext V3 option

### DIFF
--- a/packages/core/lib/v3/cache/ActCache.ts
+++ b/packages/core/lib/v3/cache/ActCache.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import type { ActHandler } from "../handlers/actHandler.js";
 import type { LLMClient } from "../llm/LLMClient.js";
 import type { Action, ActResult, Logger } from "../types/public/index.js";
-import type { Page } from "../understudy/page.js";
+import type { IStagehandPage } from "../types/private/IStagehandPage.js";
 import { CacheStorage } from "./CacheStorage.js";
 import { safeGetPageUrl, waitForCachedSelector } from "./utils.js";
 import {
@@ -40,7 +40,7 @@ export class ActCache {
 
   async prepareContext(
     instruction: string,
-    page: Page,
+    page: IStagehandPage,
     variables?: Record<string, string>,
   ): Promise<ActCacheContext | null> {
     if (!this.enabled) return null;
@@ -66,7 +66,7 @@ export class ActCache {
 
   async tryReplay(
     context: ActCacheContext,
-    page: Page,
+    page: IStagehandPage,
     timeout?: number,
     llmClientOverride?: LLMClient,
   ): Promise<ActResult | null> {
@@ -197,7 +197,7 @@ export class ActCache {
   private async replayCachedActions(
     context: ActCacheContext,
     entry: CachedActEntry,
-    page: Page,
+    page: IStagehandPage,
     timeout?: number,
     llmClientOverride?: LLMClient,
   ): Promise<ActResult> {

--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -26,7 +26,7 @@ import type {
   AvailableModel,
   Logger,
 } from "../types/public/index.js";
-import type { Page } from "../understudy/page.js";
+import type { IStagehandPage } from "../types/private/IStagehandPage.js";
 import type { V3Context } from "../understudy/context.js";
 import { CacheStorage } from "./CacheStorage.js";
 import {
@@ -143,7 +143,7 @@ export class AgentCache {
     instruction: string;
     options: SanitizedAgentExecuteOptions;
     configSignature: string;
-    page: Page;
+    page: IStagehandPage;
     variables?: Record<string, string>;
   }): Promise<AgentCacheContext | null> {
     if (!this.shouldAttemptCache(params.instruction)) {

--- a/packages/core/lib/v3/cache/utils.ts
+++ b/packages/core/lib/v3/cache/utils.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "../types/public/index.js";
-import { Page } from "../understudy/page.js";
+import type { IStagehandPage } from "../types/private/IStagehandPage.js";
 
 const DEFAULT_WAIT_TIMEOUT_MS = 15000;
 
@@ -7,7 +7,7 @@ export function cloneForCache<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
-export async function safeGetPageUrl(page: Page): Promise<string> {
+export async function safeGetPageUrl(page: IStagehandPage): Promise<string> {
   try {
     return page.url();
   } catch {
@@ -20,7 +20,7 @@ export async function safeGetPageUrl(page: Page): Promise<string> {
  * Logs a warning and proceeds if the wait times out (non-blocking).
  */
 export async function waitForCachedSelector(params: {
-  page: Page;
+  page: IStagehandPage;
   selector: string | undefined;
   timeout: number | undefined;
   logger: Logger;

--- a/packages/core/lib/v3/types/private/IStagehandPage.ts
+++ b/packages/core/lib/v3/types/private/IStagehandPage.ts
@@ -61,6 +61,17 @@ export interface IStagehandPage {
   // Init scripts — generic form matching Page exactly
   addInitScript<Arg>(script: InitScriptSource<Arg>, arg?: Arg): Promise<void>;
 
+  // Selector wait — required by ActCache.utils.waitForCachedSelector.
+  // Return type is Promise<boolean | void> to be compatible with both the CDP
+  // Page (returns boolean) and PlaywrightNativePage (returns void).
+  waitForSelector(
+    selector: string,
+    opts?: {
+      timeout?: number;
+      state?: "attached" | "detached" | "visible" | "hidden";
+    },
+  ): Promise<boolean | void>;
+
   // Close
   close(): Promise<void>;
 }

--- a/packages/core/lib/v3/types/private/internal.ts
+++ b/packages/core/lib/v3/types/private/internal.ts
@@ -11,7 +11,8 @@ export type InitState =
       createdTempProfile?: boolean;
       preserveUserDataDir?: boolean;
     }
-  | { kind: "BROWSERBASE"; bb: Browserbase; sessionId: string; ws: string };
+  | { kind: "BROWSERBASE"; bb: Browserbase; sessionId: string; ws: string }
+  | { kind: "PLAYWRIGHT_NATIVE" };
 
 export type EncodedId = `${number}-${number}`;
 

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -25,6 +25,7 @@ import { Page as PlaywrightPage } from "playwright-core";
 import { Page as PuppeteerPage } from "puppeteer-core";
 import { Page as PatchrightPage } from "patchright-core";
 import { Page } from "../../understudy/page.js";
+import { PlaywrightNativePage } from "../../understudy/native/PlaywrightNativePage.js";
 
 // =============================================================================
 // Variable Types
@@ -272,7 +273,7 @@ export interface AgentStreamCallbacks extends AgentCallbacks {
 export interface AgentExecuteOptionsBase {
   instruction: string;
   maxSteps?: number;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   highlightCursor?: boolean;
   /**
    * Previous conversation messages to continue from.

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -7,6 +7,7 @@ import type {
   StagehandZodSchema,
 } from "../../zodCompat.js";
 import { Page } from "../../understudy/page.js";
+import { PlaywrightNativePage } from "../../understudy/native/PlaywrightNativePage.js";
 import { ModelConfiguration } from "../public/model.js";
 import type { Variables } from "./agent.js";
 
@@ -14,7 +15,7 @@ export interface ActOptions {
   model?: ModelConfiguration;
   variables?: Variables;
   timeout?: number;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   /**
    * Override the instance-level serverCache setting for this request.
    * When true, enables server-side caching.
@@ -54,7 +55,7 @@ export interface ExtractOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   /**
    * Override the instance-level serverCache setting for this request.
    * When true, enables server-side caching.
@@ -75,7 +76,7 @@ export interface ObserveOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   /**
    * Override the instance-level serverCache setting for this request.
    * When true, enables server-side caching.

--- a/packages/core/lib/v3/types/public/options.ts
+++ b/packages/core/lib/v3/types/public/options.ts
@@ -6,6 +6,7 @@ import {
   type BrowserbaseSessionCreateParams,
   LocalBrowserLaunchOptionsSchema,
 } from "./api.js";
+import type { BrowserContext } from "playwright-core";
 
 export type V3Env = "LOCAL" | "BROWSERBASE";
 
@@ -19,6 +20,15 @@ export type LocalBrowserLaunchOptions = z.infer<
 /** Constructor options for V3 */
 export interface V3Options {
   env: V3Env;
+  /**
+   * Optional: provide an externally-managed Playwright BrowserContext.
+   * When set, Stagehand skips all Chrome/Browserbase launch code and wraps
+   * the provided context. The caller is responsible for closing the context.
+   * When browserContext is set, env is ignored for launch purposes.
+   * Note: env must still be set (use "LOCAL") to satisfy the type; the value
+   * is not used for browser launch when browserContext is provided.
+   */
+  browserContext?: BrowserContext;
   /**
    * Optional external session identifier to use for flow logging/event storage.
    * When omitted, Stagehand falls back to its internal instance id.

--- a/packages/core/lib/v3/types/public/page.ts
+++ b/packages/core/lib/v3/types/public/page.ts
@@ -2,9 +2,11 @@ import { Page } from "../../understudy/page.js";
 import { Page as PlaywrightPage } from "playwright-core";
 import { Page as PatchrightPage } from "patchright-core";
 import { Page as PuppeteerPage } from "puppeteer-core";
+import { PlaywrightNativePage } from "../../understudy/native/PlaywrightNativePage.js";
 
 export type { PlaywrightPage, PatchrightPage, PuppeteerPage, Page };
-export type AnyPage = PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+export { PlaywrightNativePage };
+export type AnyPage = PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
 
 export { ConsoleMessage } from "../../understudy/consoleMessage.js";
 export type { ConsoleListener } from "../../understudy/consoleMessage.js";

--- a/packages/core/lib/v3/understudy/native/PlaywrightNativeContext.ts
+++ b/packages/core/lib/v3/understudy/native/PlaywrightNativeContext.ts
@@ -1,0 +1,46 @@
+// packages/core/lib/v3/understudy/native/PlaywrightNativeContext.ts
+
+import type { BrowserContext, Page as PlaywrightPage } from "playwright-core";
+import type { LogLine } from "../../types/public/logs.js";
+import { StagehandNotInitializedError } from "../../types/public/sdkErrors.js";
+import { PlaywrightNativePage } from "./PlaywrightNativePage.js";
+
+export class PlaywrightNativeContext {
+  private _cache = new Map<PlaywrightPage, PlaywrightNativePage>();
+
+  constructor(
+    private readonly _browserContext: BrowserContext,
+    private readonly _opts: { logger: (logLine: LogLine) => void },
+  ) {}
+
+  /**
+   * Returns the cached PlaywrightNativePage for the given playwright.Page, or
+   * creates a new one. Pages are cached by reference so the same wrapper
+   * instance is returned every time for the same underlying page.
+   *
+   * Cache entries are evicted when the playwright.Page closes to prevent
+   * accumulation of stale references.
+   */
+  wrapPage(pwPage: PlaywrightPage): PlaywrightNativePage {
+    if (this._cache.has(pwPage)) return this._cache.get(pwPage)!;
+    const wrapped = new PlaywrightNativePage(pwPage, this._opts);
+    this._cache.set(pwPage, wrapped);
+    // Evict on close to prevent memory leak from accumulating closed-page refs
+    pwPage.once("close", () => this._cache.delete(pwPage));
+    return wrapped;
+  }
+
+  /**
+   * Returns a PlaywrightNativePage wrapping the first open page in the context.
+   * Throws if no pages are open.
+   */
+  getActivePage(): PlaywrightNativePage {
+    const pages = this._browserContext.pages();
+    if (pages.length === 0) {
+      throw new StagehandNotInitializedError(
+        "PlaywrightNativeContext.getActivePage(): no pages open in BrowserContext.",
+      );
+    }
+    return this.wrapPage(pages[0]);
+  }
+}

--- a/packages/core/lib/v3/understudy/native/PlaywrightNativePage.ts
+++ b/packages/core/lib/v3/understudy/native/PlaywrightNativePage.ts
@@ -1,0 +1,175 @@
+// packages/core/lib/v3/understudy/native/PlaywrightNativePage.ts
+//
+// Known Phase 4 limitations:
+// - addInitScript() delegates to playwright Page.addInitScript(), which in an
+//   externally-owned BrowserContext injects into ALL pages in the context.
+// - FlowLogger decorators are absent — PagePerformAction/PageClose events will
+//   not appear in flow logs for native mode.
+// - evaluate() rejects string expressions (CDP-ism); callers must pass functions.
+
+import type { Page as PlaywrightPage } from "playwright-core";
+import type { IStagehandPage, ResolvedAction } from "../../types/private/IStagehandPage.js";
+import type { HybridSnapshot, SnapshotOptions } from "../../types/private/snapshot.js";
+import type { ScreenshotOptions } from "../../types/public/screenshotTypes.js";
+import type { LoadState } from "../../types/public/page.js";
+import type { InitScriptSource } from "../../types/private/internal.js";
+import type { LogLine } from "../../types/public/logs.js";
+import { StagehandInvalidArgumentError } from "../../types/public/sdkErrors.js";
+import { performNativeAction } from "./actions/nativeActionDispatch.js";
+import { captureNativeSnapshot } from "./snapshot/captureNativeSnapshot.js";
+
+export class PlaywrightNativePage implements IStagehandPage {
+  private _disposed = false;
+
+  constructor(
+    public readonly _pwPage: PlaywrightPage,
+    private readonly _opts: { logger: (logLine: LogLine) => void },
+  ) {
+    // Mark disposed on page close so in-flight performAction calls throw cleanly
+    // rather than failing with an opaque Playwright "target closed" error.
+    this._pwPage.once("close", () => {
+      this._disposed = true;
+    });
+  }
+
+  // ── Identity ────────────────────────────────────────────────────────────────
+
+  url(): string {
+    return this._pwPage.url();
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  async goto(
+    url: string,
+    opts?: { waitUntil?: LoadState; timeoutMs?: number },
+  ): Promise<unknown> {
+    return this._pwPage.goto(url, {
+      waitUntil: opts?.waitUntil,
+      timeout: opts?.timeoutMs,
+    });
+  }
+
+  async reload(opts?: { waitUntil?: LoadState; timeoutMs?: number }): Promise<unknown> {
+    return this._pwPage.reload({
+      waitUntil: opts?.waitUntil,
+      timeout: opts?.timeoutMs,
+    });
+  }
+
+  async goBack(opts?: { waitUntil?: LoadState; timeoutMs?: number }): Promise<unknown> {
+    return this._pwPage.goBack({
+      waitUntil: opts?.waitUntil,
+      timeout: opts?.timeoutMs,
+    });
+  }
+
+  async goForward(opts?: { waitUntil?: LoadState; timeoutMs?: number }): Promise<unknown> {
+    return this._pwPage.goForward({
+      waitUntil: opts?.waitUntil,
+      timeout: opts?.timeoutMs,
+    });
+  }
+
+  // ── Load state ──────────────────────────────────────────────────────────────
+
+  async waitForLoadState(state: LoadState, timeoutMs?: number): Promise<void> {
+    await this._pwPage.waitForLoadState(state, { timeout: timeoutMs });
+  }
+
+  // ── DOM settle ──────────────────────────────────────────────────────────────
+
+  /**
+   * NOTE: Playwright's 'networkidle' fires after ≥500ms with ≤2 open
+   * connections. This differs from the CDP understudy's custom polling.
+   * In practice both are "good enough" for LLM inference timing.
+   */
+  async waitForNetworkIdle(domSettleTimeoutMs?: number): Promise<void> {
+    await this._pwPage.waitForLoadState("networkidle", {
+      timeout: domSettleTimeoutMs,
+    });
+  }
+
+  // ── Selector wait ────────────────────────────────────────────────────────────
+
+  async waitForSelector(
+    selector: string,
+    opts?: { timeout?: number },
+  ): Promise<void> {
+    await this._pwPage.locator(selector).waitFor({ timeout: opts?.timeout });
+  }
+
+  // ── Snapshot ────────────────────────────────────────────────────────────────
+
+  async captureSnapshot(opts?: SnapshotOptions): Promise<HybridSnapshot> {
+    return captureNativeSnapshot(this._pwPage, {
+      focusSelector: opts?.focusSelector,
+      experimental: opts?.experimental ?? false,
+      pierceShadow: opts?.pierceShadow ?? true,
+      includeIframes: opts?.includeIframes ?? true,
+    });
+  }
+
+  // ── Action ──────────────────────────────────────────────────────────────────
+
+  async performAction(action: ResolvedAction): Promise<void> {
+    if (this._disposed) {
+      throw new StagehandInvalidArgumentError(
+        "PlaywrightNativePage: page has been closed.",
+      );
+    }
+    await performNativeAction(this._pwPage, action);
+  }
+
+  // ── Evaluation ──────────────────────────────────────────────────────────────
+
+  /**
+   * Rejects string expressions — those are a CDP-ism. Pass a function instead:
+   *   page.evaluate(() => document.title)
+   */
+  async evaluate<R = unknown, Arg = unknown>(
+    fn: string | ((arg: Arg) => R | Promise<R>),
+    arg?: Arg,
+  ): Promise<R> {
+    if (typeof fn === "string") {
+      throw new StagehandInvalidArgumentError(
+        "PlaywrightNativePage.evaluate() does not support string expressions. " +
+          "Pass a function: page.evaluate(() => document.title)",
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this._pwPage.evaluate(fn as any, arg) as Promise<R>;
+  }
+
+  // ── Screenshot ──────────────────────────────────────────────────────────────
+
+  /**
+   * The `mask` option is CDP-Locator-typed and unusable in native mode.
+   * It is silently dropped. This is a known Phase 4 limitation.
+   */
+  async screenshot(opts?: ScreenshotOptions): Promise<Buffer> {
+    const { mask: _mask, ...pwOpts } = opts ?? {};
+    return this._pwPage.screenshot(pwOpts) as Promise<Buffer>;
+  }
+
+  // ── Init scripts ─────────────────────────────────────────────────────────────
+
+  /**
+   * WARNING: delegates to playwright Page.addInitScript(). In an
+   * externally-owned BrowserContext this injects into ALL pages in the
+   * context, not just this one. Known Phase 4 limitation.
+   */
+  async addInitScript<Arg>(
+    script: InitScriptSource<Arg>,
+    _arg?: Arg,
+  ): Promise<void> {
+    await this._pwPage.addInitScript(script as string);
+  }
+
+  // ── Close ────────────────────────────────────────────────────────────────────
+
+  async close(): Promise<void> {
+    this._disposed = true;
+    await this._pwPage.close();
+  }
+}

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -80,6 +80,9 @@ import {
 } from "./types/public/index.js";
 import { V3Context } from "./understudy/context.js";
 import { Page } from "./understudy/page.js";
+import { PlaywrightNativeContext } from "./understudy/native/PlaywrightNativeContext.js";
+import { PlaywrightNativePage } from "./understudy/native/PlaywrightNativePage.js";
+import type { IStagehandPage } from "./types/private/IStagehandPage.js";
 import { resolveModel } from "../modelUtils.js";
 import { StagehandAPIClient } from "./api.js";
 import { validateExperimentalFeatures } from "./agent/utils/validateExperimentalFeatures.js";
@@ -148,6 +151,7 @@ export class V3 {
   private extractHandler: ExtractHandler | null = null;
   private observeHandler: ObserveHandler | null = null;
   private ctx: V3Context | null = null;
+  private nativeCtx: PlaywrightNativeContext | null = null;
   public llmClient!: LLMClient;
 
   /**
@@ -733,6 +737,21 @@ export class V3 {
               inferenceTimeMs,
             ),
         );
+        if (this.opts.browserContext) {
+          // Validate: reject ambiguous BROWSERBASE + browserContext combination
+          if (this.opts.env === "BROWSERBASE") {
+            throw new StagehandInvalidArgumentError(
+              "Cannot use browserContext with env: 'BROWSERBASE'. " +
+                "Remove browserContext or switch to env: 'LOCAL'.",
+            );
+          }
+          this.nativeCtx = new PlaywrightNativeContext(this.opts.browserContext, {
+            logger: this.logger,
+          });
+          this.state = { kind: "PLAYWRIGHT_NATIVE" };
+          return;
+        }
+
         if (this.opts.env === "LOCAL") {
           // chrome-launcher conditionally adds --headless when the environment variable
           // HEADLESS is set, without parsing its value.
@@ -1101,10 +1120,16 @@ export class V3 {
         // Use selector as provided to support XPath, CSS, and other engines
         const selector = input.selector;
         if (this.apiClient) {
+          if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+            throw new StagehandInvalidArgumentError(
+              "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+                "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+            );
+          }
           actResult = await this.apiClient.act({
             input,
             options,
-            frameId: v3Page.mainFrameId(),
+            frameId: (v3Page as unknown as Page).mainFrameId(),
           });
         } else {
           const ensureTimeRemaining = createTimeoutGuard(
@@ -1188,7 +1213,13 @@ export class V3 {
         model: options?.model,
       };
       if (this.apiClient) {
-        const frameId = page.mainFrameId();
+        if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+          throw new StagehandInvalidArgumentError(
+            "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+              "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+          );
+        }
+        const frameId = (page as unknown as Page).mainFrameId();
         actResult = await this.apiClient.act({ input, options, frameId });
       } else {
         actResult = await this.actHandler.act(handlerParams);
@@ -1300,7 +1331,13 @@ export class V3 {
       };
       let result: z.infer<typeof effectiveSchema> | { pageText: string };
       if (this.apiClient) {
-        const frameId = page.mainFrameId();
+        if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+          throw new StagehandInvalidArgumentError(
+            "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+              "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+          );
+        }
+        const frameId = (page as unknown as Page).mainFrameId();
         result = await this.apiClient.extract({
           instruction: handlerParams.instruction,
           schema: handlerParams.schema,
@@ -1372,7 +1409,13 @@ export class V3 {
 
       let results: Action[];
       if (this.apiClient) {
-        const frameId = page.mainFrameId();
+        if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+          throw new StagehandInvalidArgumentError(
+            "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+              "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+          );
+        }
+        const frameId = (page as unknown as Page).mainFrameId();
         results = await this.apiClient.observe({
           instruction,
           options,
@@ -1400,6 +1443,11 @@ export class V3 {
     if (this.state.kind === "UNINITIALIZED") {
       throw new StagehandNotInitializedError("connectURL()");
     }
+    if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+      throw new StagehandInvalidArgumentError(
+        "connectURL() is not available in PLAYWRIGHT_NATIVE mode.",
+      );
+    }
     return this.state.ws;
   }
 
@@ -1413,6 +1461,24 @@ export class V3 {
     // If we're already closing and this isn't a forced close, no-op.
     if (this._isClosing && !opts?.force) return;
     this._isClosing = true;
+
+    // In native mode the BrowserContext is owned by the caller — do not close it.
+    // Only reset internal Stagehand state. This must come before apiClient.end().
+    if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+      this.state = { kind: "UNINITIALIZED" };
+      this.nativeCtx = null;
+      this._isClosing = false;
+      this.resetBrowserbaseSessionMetadata();
+      try { unbindInstanceLogger(this.instanceId); } catch { /* ignore */ }
+      try { await this.eventStore.destroy(); } catch { /* ignore */ }
+      try { this.bus.removeAllListeners(); } catch { /* ignore */ }
+      this._history = [];
+      this.actHandler = null;
+      this.extractHandler = null;
+      this.observeHandler = null;
+      V3._instances.delete(this);
+      return;
+    }
 
     const keepAlive = this.keepAlive === true;
 
@@ -1608,9 +1674,13 @@ export class V3 {
   }
 
   /** Resolve an external page reference or fall back to the active V3 page. */
-  private async resolvePage(page?: AnyPage): Promise<Page> {
+  private async resolvePage(page?: AnyPage): Promise<IStagehandPage> {
     if (page) {
       return await this.normalizeToV3Page(page);
+    }
+    // Native mode: this.ctx is null; use nativeCtx instead
+    if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+      return this.nativeCtx!.getActivePage();
     }
     const ctx = this.ctx;
     if (!ctx) {
@@ -1619,10 +1689,20 @@ export class V3 {
     return await ctx.awaitActivePage();
   }
 
-  private async normalizeToV3Page(input: AnyPage): Promise<Page> {
-    if (input instanceof (await import("./understudy/page.js")).Page) {
-      return input as Page;
+  private async normalizeToV3Page(input: AnyPage): Promise<IStagehandPage> {
+    // 1. Already a PlaywrightNativePage — return as-is (MUST be first; it duck-types as PlaywrightPage)
+    if (input instanceof PlaywrightNativePage) {
+      return input;
     }
+    // 2. Already a CDP Page — return as-is
+    if (input instanceof Page) {
+      return input;
+    }
+    // 3. In native mode: wrap any raw playwright.Page
+    if (this.state.kind === "PLAYWRIGHT_NATIVE" && this.isPlaywrightPage(input)) {
+      return this.nativeCtx!.wrapPage(input as PlaywrightPage);
+    }
+    // 4. CDP mode: existing Playwright/Patchright/Puppeteer paths (unchanged)
     if (this.isPlaywrightPage(input)) {
       const frameId = await this.resolveTopFrameId(input);
       const page = this.ctx!.resolvePageByMainFrameId(frameId);
@@ -1752,7 +1832,9 @@ export class V3 {
 
     if (resolvedOptions.page) {
       const normalizedPage = await this.normalizeToV3Page(resolvedOptions.page);
-      this.ctx!.setActivePage(normalizedPage);
+      if (this.state.kind !== "PLAYWRIGHT_NATIVE") {
+        this.ctx!.setActivePage(normalizedPage as unknown as Page);
+      }
     }
 
     const instruction = resolvedOptions.instruction.trim();
@@ -1761,12 +1843,16 @@ export class V3 {
 
     const cacheVariables = flattenVariables(resolvedOptions.variables);
 
+    const startPage: IStagehandPage = this.state.kind === "PLAYWRIGHT_NATIVE"
+      ? this.nativeCtx!.getActivePage()
+      : await this.ctx!.awaitActivePage();
+
     const cacheContext = this.agentCache.shouldAttemptCache(instruction)
       ? await this.agentCache.prepareContext({
           instruction,
           options: sanitizedOptions,
           configSignature: agentConfigSignature,
-          page: await this.ctx!.awaitActivePage(),
+          page: startPage,
           variables: cacheVariables,
         })
       : null;
@@ -1915,7 +2001,9 @@ export class V3 {
               const normalizedPage = await this.normalizeToV3Page(
                 resolvedOptions.page,
               );
-              this.ctx!.setActivePage(normalizedPage);
+              if (this.state.kind !== "PLAYWRIGHT_NATIVE") {
+                this.ctx!.setActivePage(normalizedPage as unknown as Page);
+              }
             }
             const instruction = resolvedOptions.instruction.trim();
             const sanitizedOptions =
@@ -1925,7 +2013,9 @@ export class V3 {
 
             let cacheContext: AgentCacheContext | null = null;
             if (this.agentCache.shouldAttemptCache(instruction)) {
-              const startPage = await this.ctx!.awaitActivePage();
+              const startPage: IStagehandPage = this.state.kind === "PLAYWRIGHT_NATIVE"
+                ? this.nativeCtx!.getActivePage()
+                : await this.ctx!.awaitActivePage();
               cacheContext = await this.agentCache.prepareContext({
                 instruction,
                 options: sanitizedOptions,
@@ -1951,6 +2041,12 @@ export class V3 {
             let result: AgentResult;
             try {
               if (this.apiClient && !this.experimental) {
+                if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+                  throw new StagehandInvalidArgumentError(
+                    "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+                      "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+                  );
+                }
                 const page = await this.ctx!.awaitActivePage();
                 result = await this.apiClient.agentExecute(
                   options,
@@ -2085,6 +2181,12 @@ export class V3 {
 
           try {
             if (this.apiClient && !this.experimental) {
+              if (this.state.kind === "PLAYWRIGHT_NATIVE") {
+                throw new StagehandInvalidArgumentError(
+                  "apiClient path is not supported in PLAYWRIGHT_NATIVE mode. " +
+                    "Remove the apiClient option or use env: 'LOCAL'/'BROWSERBASE'.",
+                );
+              }
               const page = await this.ctx!.awaitActivePage();
               result = await this.apiClient.agentExecute(
                 options ?? {},

--- a/packages/core/tests/unit/native-page-routing.test.ts
+++ b/packages/core/tests/unit/native-page-routing.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import type { EventEmitter } from "events";
+import type { BrowserContext, Page as PlaywrightPage } from "playwright-core";
+import { PlaywrightNativePage } from "../../lib/v3/understudy/native/PlaywrightNativePage.js";
+import { PlaywrightNativeContext } from "../../lib/v3/understudy/native/PlaywrightNativeContext.js";
+import { StagehandNotInitializedError } from "../../lib/v3/types/public/sdkErrors.js";
+
+// ---------- helpers ----------
+
+function makeMockPwPage(): PlaywrightPage & EventEmitter {
+  const listeners: Map<string, (() => void)[]> = new Map();
+  const page = {
+    url: vi.fn().mockReturnValue("about:blank"),
+    goto: vi.fn().mockResolvedValue(null),
+    reload: vi.fn().mockResolvedValue(null),
+    goBack: vi.fn().mockResolvedValue(null),
+    goForward: vi.fn().mockResolvedValue(null),
+    waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    waitForTimeout: vi.fn().mockResolvedValue(undefined),
+    evaluate: vi.fn().mockResolvedValue(undefined),
+    screenshot: vi.fn().mockResolvedValue(Buffer.from("")),
+    locator: vi.fn().mockReturnValue({ waitFor: vi.fn().mockResolvedValue(undefined) }),
+    mouse: { wheel: vi.fn().mockResolvedValue(undefined) },
+    addInitScript: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    once(event: string, cb: () => void) {
+      const existing = listeners.get(event) ?? [];
+      listeners.set(event, [...existing, cb]);
+    },
+    emit(event: string) {
+      const cbs = listeners.get(event) ?? [];
+      for (const cb of cbs) cb();
+    },
+  } as unknown as PlaywrightPage & EventEmitter;
+  return page;
+}
+
+function makeMockBrowserContext(
+  pages: PlaywrightPage[],
+): BrowserContext {
+  return {
+    pages: vi.fn().mockReturnValue(pages),
+  } as unknown as BrowserContext;
+}
+
+const opts = {
+  logger: vi.fn(),
+};
+
+// ---------- PlaywrightNativeContext tests ----------
+
+describe("PlaywrightNativeContext", () => {
+  it("caches wrapper by page reference", () => {
+    const mockPage1 = makeMockPwPage();
+    const mockPage2 = makeMockPwPage();
+    const ctx = new PlaywrightNativeContext(
+      makeMockBrowserContext([mockPage1, mockPage2]),
+      opts,
+    );
+    const w1a = ctx.wrapPage(mockPage1);
+    const w1b = ctx.wrapPage(mockPage1);
+    const w2 = ctx.wrapPage(mockPage2);
+    expect(w1a).toBe(w1b);        // same pw.Page → same wrapper
+    expect(w1a).not.toBe(w2);     // different pw.Page → different wrapper
+  });
+
+  it("evicts closed page from cache", () => {
+    const mockPage = makeMockPwPage();
+    const ctx = new PlaywrightNativeContext(
+      makeMockBrowserContext([mockPage]),
+      opts,
+    );
+    const first = ctx.wrapPage(mockPage);
+    // Simulate page close
+    mockPage.emit("close");
+    const second = ctx.wrapPage(mockPage);
+    expect(first).not.toBe(second); // evicted; new wrapper created
+  });
+
+  it("getActivePage() wraps the first page", () => {
+    const mockPage = makeMockPwPage();
+    const ctx = new PlaywrightNativeContext(
+      makeMockBrowserContext([mockPage]),
+      opts,
+    );
+    const active = ctx.getActivePage();
+    expect(active).toBeInstanceOf(PlaywrightNativePage);
+  });
+
+  it("getActivePage() throws when no pages exist", () => {
+    const ctx = new PlaywrightNativeContext(
+      makeMockBrowserContext([]),
+      opts,
+    );
+    expect(() => ctx.getActivePage()).toThrow(StagehandNotInitializedError);
+  });
+});
+
+// ---------- PlaywrightNativePage tests ----------
+
+describe("PlaywrightNativePage", () => {
+  it("reports disposed after page close event", () => {
+    const mockPage = makeMockPwPage();
+    const wrapped = new PlaywrightNativePage(mockPage, opts);
+    mockPage.emit("close");
+    // performAction should throw after close
+    expect(wrapped.performAction({ method: "click", selector: "#x", args: [] }))
+      .rejects.toThrow("page has been closed");
+  });
+
+  it("evaluate() throws for string expressions", async () => {
+    const mockPage = makeMockPwPage();
+    const wrapped = new PlaywrightNativePage(mockPage, opts);
+    await expect(
+      wrapped.evaluate("return document.title"),
+    ).rejects.toThrow("does not support string expressions");
+  });
+
+  it("evaluate() delegates to _pwPage for function expressions", async () => {
+    const mockPage = makeMockPwPage();
+    (mockPage.evaluate as ReturnType<typeof vi.fn>).mockResolvedValue("test-title");
+    const wrapped = new PlaywrightNativePage(mockPage, opts);
+    const result = await wrapped.evaluate(() => document.title);
+    expect(result).toBe("test-title");
+  });
+
+  it("url() delegates to _pwPage.url()", () => {
+    const mockPage = makeMockPwPage();
+    (mockPage.url as ReturnType<typeof vi.fn>).mockReturnValue("https://example.com");
+    const wrapped = new PlaywrightNativePage(mockPage, opts);
+    expect(wrapped.url()).toBe("https://example.com");
+  });
+});

--- a/packages/core/tests/unit/public-api/export-surface.test.ts
+++ b/packages/core/tests/unit/public-api/export-surface.test.ts
@@ -27,6 +27,7 @@ const publicApiShape = {
   CustomOpenAIClient: Stagehand.CustomOpenAIClient,
   LLMClient: Stagehand.LLMClient,
   LOG_LEVEL_NAMES: Stagehand.LOG_LEVEL_NAMES,
+  PlaywrightNativePage: Stagehand.PlaywrightNativePage,
   Response: Stagehand.Response,
   Stagehand: Stagehand.Stagehand,
   V3: Stagehand.V3,

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -112,7 +112,8 @@ describe("Stagehand public API types", () => {
       | Stagehand.PlaywrightPage
       | Stagehand.PuppeteerPage
       | Stagehand.PatchrightPage
-      | Stagehand.Page;
+      | Stagehand.Page
+      | Stagehand.PlaywrightNativePage;
 
     it("matches expected type shape", () => {
       expectTypeOf<Stagehand.AnyPage>().toEqualTypeOf<ExpectedAnyPage>();

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -68,6 +68,7 @@ function buildFakePage(opts?: {
     goBack: vi.fn().mockResolvedValue(null),
     goForward: vi.fn().mockResolvedValue(null),
     waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    waitForSelector: vi.fn().mockResolvedValue(undefined),
     evaluate: vi.fn().mockResolvedValue(undefined),
     screenshot: vi.fn().mockResolvedValue(Buffer.from("")),
     addInitScript: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Closes #4

## Summary

- **New files:** `PlaywrightNativePage` (implements `IStagehandPage`, wraps `playwright.Page`) and `PlaywrightNativeContext` (caches wrappers by page reference, evicts on page close)
- **V3 init:** detect `opts.browserContext`, validate BROWSERBASE conflict, create `PlaywrightNativeContext`, set state `{ kind: "PLAYWRIGHT_NATIVE" }` and return early
- **resolvePage / normalizeToV3Page:** widened return types to `IStagehandPage`; `PlaywrightNativePage` check is first branch (before duck-type checks to avoid CDP routing on camoufox)
- **close():** native-mode early-return before `apiClient.end()`, preserving caller-owned `BrowserContext`
- **agent():** guard all five `this.ctx!.setActivePage` / `awaitActivePage` call sites; guard all six `mainFrameId()` / apiClient call sites
- **Cache layer:** widened `ActCache`, `AgentCache`, `cache/utils` page parameters from `Page` to `IStagehandPage`
- **IStagehandPage:** added `waitForSelector` (required by `ActCache/utils.ts`)
- **AnyPage union:** includes `PlaywrightNativePage`; options types in `methods.ts` and `agent.ts` updated accordingly
- **Unit tests:** `native-page-routing.test.ts` — caching by reference, cache eviction, `getActivePage`, `dispose` flag, `evaluate` string rejection

## Test plan

- [x] `pnpm typecheck` exits 0
- [x] `pnpm build:esm && pnpm test:core` — 570 tests pass, no regressions
- [x] `pnpm test:native` — 15 tests pass

Adversarial brief incorporated from 2-round review.
See PHASE4_FINAL_BRIEF.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)