### PR TITLE
fix: correct demo run instructions

### DIFF
--- a/packages/core/examples/v3/demo_01_caching.ts
+++ b/packages/core/examples/v3/demo_01_caching.ts
@@ -6,8 +6,9 @@
  *   RUN 1 (cold): LLM resolves every selector  → ~3–8s per step
  *   RUN 2 (warm): Selectors replayed from disk  → <50ms per step
  *
- * Run:
- *   pnpm example v3/demo_01_caching
+ * Run (from repo root):
+ *   set -a && source .env && set +a
+ *   cd packages/core && pnpm example v3/demo_01_caching
  *
  * Optional env:
  *   OPENROUTER_API_KEY  (preferred)

--- a/packages/core/examples/v3/demo_02_camoufox_extract.ts
+++ b/packages/core/examples/v3/demo_02_camoufox_extract.ts
@@ -10,8 +10,9 @@
  *   • extract() — pulling structured JSON from a live page
  *   • The ARIA snapshot that drives both (Phase 6/7 improvements)
  *
- * Run:
- *   pnpm example v3/demo_02_camoufox_extract
+ * Run (from repo root):
+ *   set -a && source .env && set +a
+ *   cd packages/core && pnpm example v3/demo_02_camoufox_extract
  *
  * Required env:
  *   CAMOUFOX_WS         — WebSocket URL printed by camoufox on startup

--- a/packages/core/examples/v3/demo_03_shadow_dom.ts
+++ b/packages/core/examples/v3/demo_03_shadow_dom.ts
@@ -7,8 +7,9 @@
  *   pierceShadow: true             → sees open shadows, MISSES closed shadows
  *   pierceShadow: "including-closed" → sees BOTH open and closed shadows
  *
- * Run:
- *   pnpm example v3/demo_03_shadow_dom
+ * Run (from repo root):
+ *   cd packages/core && pnpm example v3/demo_03_shadow_dom
+ *   (no API key needed — headless Chromium only)
  */
 
 import { chromium } from "playwright-core";

--- a/packages/docs/v3/best-practices/shadow-dom.mdx
+++ b/packages/docs/v3/best-practices/shadow-dom.mdx
@@ -150,7 +150,8 @@ A runnable demo comparing both modes is at:
 [`packages/core/examples/v3/demo_03_shadow_dom.ts`](https://github.com/browserbase/stagehand/blob/main/packages/core/examples/v3/demo_03_shadow_dom.ts)
 
 ```bash
-pnpm example v3/demo_03_shadow_dom
+# From repo root — no API key needed
+cd packages/core && pnpm example v3/demo_03_shadow_dom
 ```
 
 ---

--- a/packages/docs/v3/configuration/playwright-native.mdx
+++ b/packages/docs/v3/configuration/playwright-native.mdx
@@ -209,9 +209,14 @@ A fully-annotated demo is available at [`packages/core/examples/v3/demo_02_camou
 Run it with:
 
 ```bash
-# Set env vars in .env
-CAMOUFOX_WS=ws://localhost:PORT/TOKEN
-OPENAI_API_KEY=...   # or OPENROUTER_API_KEY
-
+# From repo root — source your .env, then run from packages/core
+set -a && source .env && set +a
+cd packages/core
 pnpm example v3/demo_02_camoufox_extract
+```
+
+Required `.env` variables:
+```bash
+CAMOUFOX_WS=ws://localhost:PORT/TOKEN   # printed by camoufox on startup
+OPENAI_API_KEY=...                       # or OPENROUTER_API_KEY
 ```


### PR DESCRIPTION
## Summary

- Demo `.ts` files were missing `cd packages/core` before `pnpm example` and the `.env` sourcing step
- MDX docs had the same incomplete run commands

## Changes

- `demo_01_caching.ts`, `demo_02_camoufox_extract.ts`, `demo_03_shadow_dom.ts` — updated header comments with correct two-step run process
- `v3/configuration/playwright-native.mdx` — fixed camoufox demo run block, split env vars into a separate block
- `v3/best-practices/shadow-dom.mdx` — fixed shadow DOM demo run command

🤖 Generated with [Claude Code](https://claude.com/claude-code)